### PR TITLE
db: add a method to retrieve the size of an entry

### DIFF
--- a/db.go
+++ b/db.go
@@ -28,7 +28,7 @@ type Database interface {
 	// data, or fail with an error.
 	Delete(key uint64) error
 
-	// Size returns the storage size of the value belonging to the iven key.
+	// Size returns the storage size of the value belonging to the given key.
 	Size(key uint64) uint32
 
 	// Limits returns the smallest and largest slot size.

--- a/db_test.go
+++ b/db_test.go
@@ -72,28 +72,40 @@ func TestDBBasics(t *testing.T) {
 	}
 	k0, _ := db.Put(fill(0, 140))
 	k1, _ := db.Put(fill(1, 140))
-	k2, _ := db.Put(fill(2, 140))
-	k3, _ := db.Put(fill(3, 140))
+	k2, _ := db.Put(fill(2, 280))
+	k3, _ := db.Put(fill(3, 280))
 
 	if have, err := db.Get(k0); err != nil {
 		t.Fatal(err)
 	} else if want := fill(0, 140); !bytes.Equal(have, want) {
 		t.Fatalf(" have\n%x\n want\n%x", have, want)
 	}
+	if have := db.Size(k0); have != 256 {
+		t.Fatalf(" have\n%d\n want\n%d", have, 256)
+	}
 	if have, err := db.Get(k1); err != nil {
 		t.Fatal(err)
 	} else if want := fill(1, 140); !bytes.Equal(have, want) {
 		t.Fatalf(" have\n%x\n want\n%x", have, want)
 	}
+	if have := db.Size(k1); have != 256 {
+		t.Fatalf(" have\n%d\n want\n%d", have, 256)
+	}
 	if have, err := db.Get(k2); err != nil {
 		t.Fatal(err)
-	} else if want := fill(2, 140); !bytes.Equal(have, want) {
+	} else if want := fill(2, 280); !bytes.Equal(have, want) {
 		t.Fatalf(" have\n%x\n want\n%x", have, want)
+	}
+	if have := db.Size(k2); have != 512 {
+		t.Fatalf(" have\n%d\n want\n%d", have, 512)
 	}
 	if have, err := db.Get(k3); err != nil {
 		t.Fatal(err)
-	} else if want := fill(3, 140); !bytes.Equal(have, want) {
+	} else if want := fill(3, 280); !bytes.Equal(have, want) {
 		t.Fatalf(" have\n%x\n want\n%x", have, want)
+	}
+	if have := db.Size(k3); have != 512 {
+		t.Fatalf(" have\n%d\n want\n%d", have, 512)
 	}
 }
 


### PR DESCRIPTION
This PR adds a new method to a billy.Database (`Size`) to retrieve the slot size belonging to an entry.

The purpose is if we want to evict multiple smaller items in favor of a larger one in a calling application, then we need to know how many(and which ones) to evict after inserting a new item. Without this method, the calling app would need to replicate shelf size tracking and other billy internals. With this method we can just maintain the size of items in the memory index and pick and chose from there without caring how they are managed by billy.