### PR TITLE
Return the slot size during item iteration too

### DIFF
--- a/cmd/billy/main.go
+++ b/cmd/billy/main.go
@@ -113,7 +113,7 @@ func openDb(ctx *cli.Context) (billy.Database, *dbParams, error) {
 }
 
 func doOpenDb(opts *dbParams) (billy.Database, error) {
-	db, err := billy.Open(billy.Options{Path: opts.path}, billy.SlotSizePowerOfTwo(opts.min, opts.max), func(key uint64, data []byte) {
+	db, err := billy.Open(billy.Options{Path: opts.path}, billy.SlotSizePowerOfTwo(opts.min, opts.max), func(key uint64, size uint32, data []byte) {
 		var d string
 		if len(data) > 100 {
 			d = fmt.Sprintf("%q...", data[:100])

--- a/cmd/billyfuzz/main.go
+++ b/cmd/billyfuzz/main.go
@@ -70,7 +70,7 @@ func doFuzz(ctx *cli.Context) error {
 	var (
 		hasher = sha256.New()
 		hashes = make(map[uint64]string)
-		onData = func(key uint64, data []byte) {
+		onData = func(key uint64, size uint32, data []byte) {
 			if verbose {
 				fmt.Printf("init key %x val %x\n", key, data[:20])
 			}

--- a/db_test.go
+++ b/db_test.go
@@ -272,12 +272,12 @@ func TestSizes(t *testing.T) {
 		}
 		kvdata[key] = string(have)
 	}
-	err = db.Iterate(func(key uint64, data []byte) {
-		want := kvdata[key]
-		have := string(data)
-		if have != want {
-			t.Fatalf("iteration fail, key %d\nhave: %x\nwant: %x\n",
-				key, have, want)
+	err = db.Iterate(func(key uint64, size uint32, data []byte) {
+		wantVal := kvdata[key]
+		wantSize := uint32(((len(wantVal) + itemHeaderSize + 9) / 10) * 10)
+		if string(data) != wantVal || size != wantSize {
+			t.Fatalf("iteration fail, key %d\nhave data: %x\nwant data: %x\nhave size: %d\nwant size: %d\n",
+				key, data, wantVal, size, wantSize)
 		}
 	})
 	if err != nil {
@@ -291,7 +291,7 @@ func TestSizes(t *testing.T) {
 		}
 	}
 	// Expect nothing to remaing
-	err = db.Iterate(func(key uint64, data []byte) {
+	err = db.Iterate(func(key uint64, size uint32, data []byte) {
 		t.Fatalf("Expected empty db, key %d", key)
 	})
 	if err != nil {

--- a/shelf.go
+++ b/shelf.go
@@ -323,7 +323,6 @@ type onShelfDataFn func(slot uint64, data []byte)
 // Iterate iterates through the elements on the shelf, and invokes the onData
 // callback for each item.
 func (s *shelf) Iterate(onData onShelfDataFn) error {
-
 	s.gapsMu.Lock()
 	defer s.gapsMu.Unlock()
 


### PR DESCRIPTION
Turns out that billy.Size is not enough to properly handle this aspect of the database because during Open there is no database instance yet to query the Size through. That would require a second pass over the data post-Open, which is moot if Open already did it once.

This PR extends the iterator's OnDataFn to also receive the slot size.