### PR TITLE
Expose slot metrics to the user APIs

### DIFF
--- a/db.go
+++ b/db.go
@@ -34,6 +34,9 @@ type Database interface {
 	// Limits returns the smallest and largest slot size.
 	Limits() (uint32, uint32)
 
+	// Infos retrieves various internal statistics about the database.
+	Infos() *Infos
+
 	// Iterate iterates through all the data in the database, and invokes the
 	// given onData method for every element
 	Iterate(onData OnDataFn) error

--- a/infos.go
+++ b/infos.go
@@ -20,10 +20,12 @@ type ShelfInfos struct {
 func (db *database) Infos() *Infos {
 	infos := new(Infos)
 	for _, shelf := range db.shelves {
+		slots, gaps := shelf.stats()
+
 		infos.Shelves = append(infos.Shelves, &ShelfInfos{
 			SlotSize:    shelf.slotSize,
-			FilledSlots: shelf.count - uint64(len(shelf.gaps)),
-			GappedSlots: uint64(len(shelf.gaps)),
+			FilledSlots: slots - gaps,
+			GappedSlots: gaps,
 		})
 	}
 	return infos

--- a/infos.go
+++ b/infos.go
@@ -1,0 +1,30 @@
+// bagdb: Simple datastorage
+// Copyright 2023 billy authors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package billy
+
+// Infos contains a set of statistics about the underlying datastore.
+type Infos struct {
+	Shelves []*ShelfInfos
+}
+
+// ShelfInfos contains some statistics about the data stored in a single shelf.
+type ShelfInfos struct {
+	SlotSize    uint32
+	FilledSlots uint64
+	GappedSlots uint64
+}
+
+// Infos gathers and returns some stats about the database.
+func (db *database) Infos() *Infos {
+	infos := new(Infos)
+	for _, shelf := range db.shelves {
+		infos.Shelves = append(infos.Shelves, &ShelfInfos{
+			SlotSize:    shelf.slotSize,
+			FilledSlots: shelf.count - uint64(len(shelf.gaps)),
+			GappedSlots: uint64(len(shelf.gaps)),
+		})
+	}
+	return infos
+}

--- a/shelf.go
+++ b/shelf.go
@@ -465,6 +465,14 @@ func (s *shelf) compact(onData onShelfDataFn) error {
 	return nil
 }
 
+// stats returns the total number of slots in the shelf and the gaps within.
+func (s *shelf) stats() (uint64, uint64) {
+	s.gapsMu.Lock()
+	defer s.gapsMu.Unlock()
+
+	return s.count, uint64(len(s.gaps))
+}
+
 // sortedUniqueInts is a helper structure to maintain an ordered slice
 // of gaps. We keep them ordered to make writes prefer early slots, to increase
 // the chance of trimming the end of files upon deletion.


### PR DESCRIPTION
I'm trying to plot via metrics how much overhead we have vs useful data in Billy. For that I need to expose the gap count in the shelves. The PR exposes a few more things for completeness sake.