### PR TITLE
Add support for opening databases in-memory if path is empty

### DIFF
--- a/shelf_test.go
+++ b/shelf_test.go
@@ -36,7 +36,10 @@ func checkBlob(fill byte, blob []byte, size int) error {
 	return nil
 }
 
-func TestBasics(t *testing.T) {
+func TestBasicsInMemory(t *testing.T) { testBasics(t, "") }
+func TestBasicsOnDisk(t *testing.T)   { testBasics(t, t.TempDir()) }
+
+func testBasics(t *testing.T, path string) {
 	{ // Pre-instance failures
 		// can't open non-existing directory
 		if _, err := openShelf("/baz/bonk/foobar/gazonk", 10, nil, false); err == nil {
@@ -47,7 +50,7 @@ func TestBasics(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	}
-	b, cleanup := setup(t)
+	b, cleanup := setup(t, path)
 	defer cleanup()
 	{ // Tests on Put
 		// Should reject empty data
@@ -221,9 +224,9 @@ func checkIdentical(fileA, fileB string) error {
 	return nil
 }
 
-func setup(t *testing.T) (*shelf, func()) {
+func setup(t *testing.T, path string) (*shelf, func()) {
 	t.Helper()
-	a, err := openShelf(t.TempDir(), 200, nil, false)
+	a, err := openShelf(path, 200, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,8 +238,12 @@ func setup(t *testing.T) (*shelf, func()) {
 // TestOversized
 // - Test writing oversized data into a shelf
 // - Test writing exactly-sized data into a shelf
-func TestOversized(t *testing.T) {
-	a, cleanup := setup(t)
+
+func TestOversizedInMemory(t *testing.T) { testOversized(t, "") }
+func TestOversizedOnDisk(t *testing.T)   { testOversized(t, t.TempDir()) }
+
+func testOversized(t *testing.T, path string) {
+	a, cleanup := setup(t, path)
 	defer cleanup()
 
 	for s := 190; s < 205; s++ {
@@ -259,8 +266,12 @@ func TestOversized(t *testing.T) {
 
 // TestErrOnClose
 // - Tests reading, writing, deleting from a closed shelf
-func TestErrOnClose(t *testing.T) {
-	a, cleanup := setup(t)
+
+func TestErrOnCloseInMemory(t *testing.T) { testErrOnClose(t, "") }
+func TestErrOnCloseOnDisk(t *testing.T)   { testErrOnClose(t, t.TempDir()) }
+
+func testErrOnClose(t *testing.T, path string) {
+	a, cleanup := setup(t, path)
 	defer cleanup()
 	// Write something and delete it again, to have a gap
 	if have, want := a.count, uint64(0); have != want {
@@ -308,8 +319,11 @@ func TestErrOnClose(t *testing.T) {
 	}
 }
 
-func TestBadInput(t *testing.T) {
-	a, cleanup := setup(t)
+func TestBadInputInMemory(t *testing.T) { testBadInput(t, "") }
+func TestBadInputOnDisk(t *testing.T)   { testBadInput(t, t.TempDir()) }
+
+func testBadInput(t *testing.T, path string) {
+	a, cleanup := setup(t, path)
 	defer cleanup()
 
 	if _, err := a.Put(make([]byte, 25)); err != nil {

--- a/shelf_test.go
+++ b/shelf_test.go
@@ -636,7 +636,7 @@ func TestVersion(t *testing.T) {
 		},
 		{ // Too short
 			hdr:  []byte{'b'},
-			want: "unexpected EOF",
+			want: "EOF",
 		},
 	} {
 		if err := os.WriteFile(filepath.Join(p, fname), tc.hdr, 0o777); err != nil {

--- a/store.go
+++ b/store.go
@@ -1,0 +1,41 @@
+// bagdb: Simple datastorage
+// Copyright 2021 billy authors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package billy
+
+import (
+	"io"
+	"os"
+	"time"
+)
+
+// store is an interface mimicking an os.File to allow using different storage
+// backends for different database instances.
+type store interface {
+	io.Reader
+	io.ReaderAt
+	io.Writer
+	io.WriterAt
+	io.Closer
+
+	Stat() (os.FileInfo, error)
+	Truncate(size int64) error
+	Sync() error
+}
+
+// fileinfoMock is a mock implementation for returning non-single-file store
+// sizes.
+type fileinfoMock struct {
+	size int64
+}
+
+func (s *fileinfoMock) Size() int64 {
+	return s.size
+}
+
+func (s *fileinfoMock) Name() string       { panic("not implemented") }
+func (s *fileinfoMock) Mode() os.FileMode  { panic("not implemented") }
+func (s *fileinfoMock) ModTime() time.Time { panic("not implemented") }
+func (s *fileinfoMock) IsDir() bool        { panic("not implemented") }
+func (s *fileinfoMock) Sys() any           { panic("not implemented") }

--- a/store.go
+++ b/store.go
@@ -13,9 +13,7 @@ import (
 // store is an interface mimicking an os.File to allow using different storage
 // backends for different database instances.
 type store interface {
-	io.Reader
 	io.ReaderAt
-	io.Writer
 	io.WriterAt
 	io.Closer
 

--- a/store_memory.go
+++ b/store_memory.go
@@ -14,18 +14,7 @@ import (
 // memoryStore implements store for in-memory ephemeral data persistence.
 type memoryStore struct {
 	buffer []byte
-	offset int64
 	lock   sync.Mutex
-}
-
-// Read implements io.Reader of the store interface.
-func (ms *memoryStore) Read(p []byte) (int, error) {
-	ms.lock.Lock()
-	defer ms.lock.Unlock()
-
-	n, err := ms.readAt(p, ms.offset)
-	ms.offset += int64(n)
-	return n, err
 }
 
 // ReadAt implements io.ReaderAt of the store interface.
@@ -53,16 +42,6 @@ func (ms *memoryStore) readAt(p []byte, off int64) (int, error) {
 		fail = io.EOF
 	}
 	return read, fail
-}
-
-// Write implements io.Writer of the store interface.
-func (ms *memoryStore) Write(p []byte) (int, error) {
-	ms.lock.Lock()
-	defer ms.lock.Unlock()
-
-	n, err := ms.writeAt(p, ms.offset)
-	ms.offset += int64(n)
-	return n, err
 }
 
 // WriteAt implements io.WriterAt of the store interface.

--- a/store_memory.go
+++ b/store_memory.go
@@ -1,0 +1,117 @@
+// bagdb: Simple datastorage
+// Copyright 2021 billy authors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package billy
+
+import (
+	"errors"
+	"io"
+	"os"
+	"sync"
+)
+
+// memoryStore implements store for in-memory ephemeral data persistence.
+type memoryStore struct {
+	buffer []byte
+	offset int64
+	lock   sync.Mutex
+}
+
+// Read implements io.Reader of the store interface.
+func (ms *memoryStore) Read(p []byte) (int, error) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	n, err := ms.readAt(p, ms.offset)
+	ms.offset += int64(n)
+	return n, err
+}
+
+// ReadAt implements io.ReaderAt of the store interface.
+func (ms *memoryStore) ReadAt(p []byte, off int64) (int, error) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	return ms.readAt(p, off)
+}
+
+// readAt is the actual implementation of Read/ReadAt.
+func (ms *memoryStore) readAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, errors.New("memoryStore.ReadAt: negative offset")
+	}
+	if off >= int64(len(ms.buffer)) {
+		return 0, io.EOF
+	}
+	copy(p, ms.buffer[off:])
+	read := len(p)
+	fail := error(nil)
+
+	if off += int64(read); off > int64(len(ms.buffer)) {
+		read -= int(off - int64(len(ms.buffer)))
+		fail = io.EOF
+	}
+	return read, fail
+}
+
+// Write implements io.Writer of the store interface.
+func (ms *memoryStore) Write(p []byte) (int, error) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	n, err := ms.writeAt(p, ms.offset)
+	ms.offset += int64(n)
+	return n, err
+}
+
+// WriteAt implements io.WriterAt of the store interface.
+func (ms *memoryStore) WriteAt(p []byte, off int64) (int, error) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	return ms.writeAt(p, off)
+}
+
+// writeAt is the actual implementation of Write/WriteAt.
+func (ms *memoryStore) writeAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, errors.New("memoryStore.WriteAt: negative offset")
+	}
+	if off+int64(len(p)) > int64(len(ms.buffer)) {
+		ms.buffer = append(ms.buffer, make([]byte, off+int64(len(p))-int64(len(ms.buffer)))...)
+	}
+	copy(ms.buffer[off:], p)
+	return len(p), nil
+}
+
+// Close implements io.Closer of the store interface.
+func (ms *memoryStore) Close() error {
+	return nil
+}
+
+// Stat implements the store interface.
+func (ms *memoryStore) Stat() (os.FileInfo, error) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	return &fileinfoMock{size: int64(len(ms.buffer))}, nil
+}
+
+// Truncate implements the store interface.
+func (ms *memoryStore) Truncate(size int64) error {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	if int64(len(ms.buffer)) >= size {
+		ms.buffer = ms.buffer[:size]
+	} else {
+		ms.buffer = append(ms.buffer, make([]byte, size-int64(len(ms.buffer)))...)
+	}
+	return nil
+}
+
+// Sync implements the store interface.
+func (ms *memoryStore) Sync() error {
+	return nil
+}

--- a/store_memory_test.go
+++ b/store_memory_test.go
@@ -1,0 +1,40 @@
+// bagdb: Simple datastorage
+// Copyright 2021 billy authors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package billy
+
+import "testing"
+
+func TestMemoryStore(t *testing.T) {
+	ms := new(memoryStore)
+	for i, want := range []int64{100, 150, 149, 99, 0} {
+		if err := ms.Truncate(want); err != nil {
+			t.Fatal(err)
+		}
+		if have := int64(len(ms.buffer)); have != want {
+			t.Fatalf("test %d: have %d want %d", i, have, want)
+		}
+	}
+}
+
+func TestOutOfBands(t *testing.T) {
+	ms := new(memoryStore)
+	if _, err := ms.WriteAt(make([]byte, 0), -1); err == nil {
+		t.Fatal("want error, got none")
+	}
+	if _, err := ms.ReadAt(make([]byte, 0), -1); err == nil {
+		t.Fatal("want error, got none")
+	}
+	// Make it a bit larger
+	if err := ms.Truncate(100); err != nil {
+		t.Fatal(err)
+	}
+	n, err := ms.ReadAt(make([]byte, 20), 90)
+	if err == nil {
+		t.Fatal("want error, got none")
+	}
+	if n != 10 {
+		t.Fatalf("expected to read %d bytes, read %d", 10, n)
+	}
+}


### PR DESCRIPTION
This PR replaces the *os.File with a `store` interface to allow having multiple different backens. The PR also implements and integrates the in-memory backend to use if the database path given is empty.

Btw, this interface can be used by the multi-file capped PR too, would integrate nicely with very minimal changes needed.