### PR TITLE
db, shelf: ensure magic is correct, speed up shelf size code paths

### DIFF
--- a/db.go
+++ b/db.go
@@ -105,6 +105,7 @@ func Open(opts Options, slotSizeFn SlotSizeFn, onData OnDataFn) (Database, error
 		prevSlotSize uint32
 		prevId       int
 		slotSize     uint32
+		slotSizes    []uint32
 		done         bool
 	)
 	for !done {
@@ -113,18 +114,21 @@ func Open(opts Options, slotSizeFn SlotSizeFn, onData OnDataFn) (Database, error
 			return nil, fmt.Errorf("slot sizes must be in increasing order")
 		}
 		prevSlotSize = slotSize
+
+		slotSizes = append(slotSizes, slotSize)
+		if id := len(slotSizes) & 0xfff; id < prevId {
+			return nil, fmt.Errorf("too many shelves (%d)", len(slotSizes))
+		} else {
+			prevId = id
+		}
+	}
+	for _, slotSize = range slotSizes {
 		shelf, err := openShelf(opts.Path, slotSize, wrapShelfDataFn(len(db.shelves), slotSize, onData), opts.Readonly)
 		if err != nil {
 			db.Close() // Close shelves
 			return nil, err
 		}
 		db.shelves = append(db.shelves, shelf)
-
-		if id := len(db.shelves) & 0xfff; id < prevId {
-			return nil, fmt.Errorf("too many shelves (%d)", len(db.shelves))
-		} else {
-			prevId = id
-		}
 	}
 	return db, nil
 }

--- a/shelf_test.go
+++ b/shelf_test.go
@@ -638,15 +638,20 @@ func TestVersion(t *testing.T) {
 			hdr:  []byte{'b'},
 			want: "EOF",
 		},
+		{ // Correct magic, empty shelf
+			hdr:  []byte{'b', 'i', 'l', 'l', 'y', 0x00, 0x00, 0x00, 0x00, 0x00, 100},
+			want: "",
+		},
 	} {
 		if err := os.WriteFile(filepath.Join(p, fname), tc.hdr, 0o777); err != nil {
 			t.Fatal(err)
 		}
 		_, err := openShelf(p, size, nil, false)
 		if err == nil {
-			t.Fatal("expected error")
-		}
-		if have := err.Error(); have != tc.want {
+			if tc.want != "" {
+				t.Fatal("expected error")
+			}
+		} else if have := err.Error(); have != tc.want {
 			t.Fatalf("test %d: wrong error, have '%v' want '%v'", i, have, tc.want)
 		}
 	}


### PR DESCRIPTION
This PR makes a couple tweaks to the shelf opening code:

- When opening a new shelf that does not exist, the PR adds an `fsync` after writing the magic. The idea being that OSes are a bit different wrt cached data when they crash: some OSes expand the file to the needed size and don't write anything, others don't expand the file. This kind of leads ti different behaviours that might be hard to investigate. Adding an fsync after writing the magic should be irrelevant runtime wise, but will ensure that the shelves at least have this baseline guarantee that the magic is there and correct. This will allow us to "repair" corrupted shelves by knowing for sure that they are at least surely a shelf and not some random data the user pointed to.
- When reading the magic, the PR modifies the read so it doesn't look at a returns error, rather the number of bytes read. This feels wonky, but the `ReadAt` spec says that returning `len(p), EOF` is valid, so some OS/file implementations maybe (?), might (?), return EOF if opening an empty shelf, which would still be successful if the magic is correct. The PR ensures that such wonky cases are handled correctly.
- A last change is in the `openShelf`, where the shelf sizes are all pre-generated first, before starting to du actual disk operations. The reason being that if the shelf size generator is invalid, there's no point to do file ops. This specifically hit on MacOS with the fsync where the test case that opened 4K shelves needed 4K fsyncs, which is 20s (5ms / fsync) :/.
- Lastly, the PR adds a test for the empty-but-correct shelf case.