### PR TITLE
db, shelf: allow repairing the db by dropping corrupted data

### DIFF
--- a/db.go
+++ b/db.go
@@ -88,6 +88,7 @@ type database struct {
 type Options struct {
 	Path     string
 	Readonly bool
+	Repair   bool
 	Snappy   bool // unused for now
 }
 
@@ -123,7 +124,7 @@ func Open(opts Options, slotSizeFn SlotSizeFn, onData OnDataFn) (Database, error
 		}
 	}
 	for _, slotSize = range slotSizes {
-		shelf, err := openShelf(opts.Path, slotSize, wrapShelfDataFn(len(db.shelves), slotSize, onData), opts.Readonly)
+		shelf, err := openShelf(opts.Path, slotSize, wrapShelfDataFn(len(db.shelves), slotSize, onData), opts.Readonly, opts.Repair)
 		if err != nil {
 			db.Close() // Close shelves
 			return nil, err

--- a/shelf.go
+++ b/shelf.go
@@ -68,7 +68,7 @@ type shelfHeader struct {
 // If the shelf already exists, it's opened and read, which populates the
 // internal gap-list.
 // The onData callback is optional, and can be nil.
-func openShelf(path string, slotSize uint32, onData onShelfDataFn, readonly bool) (*shelf, error) {
+func openShelf(path string, slotSize uint32, onData onShelfDataFn, readonly bool, repair bool) (*shelf, error) {
 	if slotSize < minSlotSize {
 		return nil, fmt.Errorf("slot size %d smaller than minimum (%d)", slotSize, minSlotSize)
 	}
@@ -115,6 +115,7 @@ func openShelf(path string, slotSize uint32, onData onShelfDataFn, readonly bool
 		if _, err = f.WriteAt(a.Bytes(), 0); err == nil {
 			err = f.Sync()
 		}
+		fileSize = len(a.Bytes())
 	} else {
 		b := make([]byte, binary.Size(h))
 		if n, err = f.ReadAt(b, 0); n == len(b) {
@@ -137,18 +138,29 @@ func openShelf(path string, slotSize uint32, onData onShelfDataFn, readonly bool
 		_ = f.Close()
 		return nil, err
 	}
-	dataSize := fileSize
-	if fileSize >= int(ShelfHeaderSize) {
-		dataSize = fileSize - int(ShelfHeaderSize)
+	dataSize := fileSize - ShelfHeaderSize
+	if extra := dataSize % int(slotSize); extra != 0 {
+		if !readonly && repair {
+			if err = f.Truncate(int64(fileSize - extra)); err == nil {
+				fileSize -= extra
+				dataSize -= extra
+			}
+		} else {
+			err = fmt.Errorf("content truncated, size:%d, slot:%d", dataSize, slotSize)
+		}
+	}
+	if err != nil {
+		_ = f.Close()
+		return nil, err
 	}
 	sh := &shelf{
 		slotSize: slotSize,
-		count:    uint64((dataSize + int(slotSize) - 1) / int(slotSize)),
+		count:    uint64(dataSize / int(slotSize)),
 		f:        f,
 		readonly: readonly,
 	}
 	// Compact + iterate
-	if err := sh.compact(onData); err != nil {
+	if err := sh.compact(onData, repair); err != nil {
 		_ = f.Close()
 		return nil, err
 	}
@@ -383,7 +395,7 @@ func (s *shelf) Iterate(onData onShelfDataFn) error {
 
 // compact moves data 'up' to fill gaps, and truncates the file afterwards.
 // This operation must only be performed during the opening of the shelf.
-func (s *shelf) compact(onData onShelfDataFn) error {
+func (s *shelf) compact(onData onShelfDataFn, repair bool) error {
 	s.gapsMu.Lock()
 	defer s.gapsMu.Unlock()
 	s.fileMu.RLock()
@@ -396,6 +408,9 @@ func (s *shelf) compact(onData onShelfDataFn) error {
 		for ; slot < s.count; slot++ {
 			data, err := s.readSlot(buf, slot)
 			if err != nil {
+				if errors.Is(err, ErrCorruptData) && !s.readonly && repair { // Repair corruption by dropping it
+					break
+				}
 				return 0, err
 			}
 			if len(data) == 0 { // We've found a gap
@@ -413,7 +428,9 @@ func (s *shelf) compact(onData onShelfDataFn) error {
 		for ; slot > gap && slot > 0; slot-- {
 			data, err := s.readSlot(buf, slot)
 			if err != nil {
-				return 0, err
+				if !errors.Is(err, ErrCorruptData) || s.readonly || !repair { // Only error if it's not a corruption being repaired
+					return 0, err
+				}
 			}
 			if len(data) != 0 {
 				// We've found a slot of data. Copy it to the gap

--- a/shelf.go
+++ b/shelf.go
@@ -141,10 +141,10 @@ func openShelf(path string, slotSize uint32, onData onShelfDataFn, readonly bool
 	dataSize := fileSize - ShelfHeaderSize
 	if extra := dataSize % int(slotSize); extra != 0 {
 		if !readonly && repair {
-			if err = f.Truncate(int64(fileSize - extra)); err == nil {
-				fileSize -= extra
-				dataSize -= extra
-			}
+			fileSize -= extra
+			dataSize -= extra
+
+			err = f.Truncate(int64(fileSize))
 		} else {
 			err = fmt.Errorf("content truncated, size:%d, slot:%d", dataSize, slotSize)
 		}

--- a/shelf_test.go
+++ b/shelf_test.go
@@ -677,7 +677,7 @@ func FuzzShelfContents(f *testing.F) {
 		}
 		shelf, err = openShelf(path, 100, nil, false, true)
 		if err != nil {
-			t.Fatalf("failed to recover shef: %v", err)
+			t.Fatalf("failed to recover shelf: %v", err)
 		}
 		shelf.Close()
 	})


### PR DESCRIPTION
Assuming that the shelf magic is correct (we fsynced the header), the contents of the shelf might be corrupted in a variety of ways:

- The shelf's length is invalid, as in the last item is not a whole slot.
- The shelf's length is valid, but within a slot, the item header is invalid (defines an items that does not fit the slot).
- The shelf's length and slot item header is correct, but the data itself is corrupted.

The 3rd case is not Billy's problem. Billy is a "dumb" data store, so if something got corrupted whilst maintaining the database schema, the outer process needs to deal with it. In Geth's case, this is handled: if a blob cannot be decoded, it will be dropped.

The first 2 cases however need to be handled by Billy and currently are not. In both cases, Billy will fail on startup when iterating the content. Whilst we could argue that failing and letting the outer user resolve it is not a bad thing, there's also no real way to automatically resolve these by Geth: we don't want to know the internal structure of the db, and going in hot deleting an entire folder seems a nuclear option.

This PR instead adds a `repair` mode into Billy. If the database is opened in RW mode *and* repairing is requested, then the above two scenarios will be fixed:

- If the shelf content is not a multiple of item sizes, the last (partial) item will be truncated (losing the data, no other way).
- If the shelf content is a good multiple (or was already truncated), but the item header is corrupted, then it will be considered a gap during the opening "ceremony" and will be silently compacted out.

In both these scenarios, the repair is destructive. That said, for Geth's use case this is fine, but even more in general, if the database dat format is borked, theres not much more we can do really. A partial data loss seems preferable vs a total data loss.