### PR TITLE
shelf: improve error-message on corrupt files

### DIFF
--- a/shelf_test.go
+++ b/shelf_test.go
@@ -651,8 +651,8 @@ func TestVersion(t *testing.T) {
 			if tc.want != "" {
 				t.Fatal("expected error")
 			}
-		} else if have := err.Error(); have != tc.want {
-			t.Fatalf("test %d: wrong error, have '%v' want '%v'", i, have, tc.want)
+		} else if have := err.Error(); !strings.HasPrefix(have, tc.want) {
+			t.Errorf("test %d: wrong error, have '%v' want '%v'", i, have, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Reference: https://github.com/ethereum/go-ethereum/issues/29303#issuecomment-2011358745

This PR adds more detailed error message when data-corruption is encountered, to make it easier to debug/repair externally. 